### PR TITLE
support doi as filename for DOI downloads

### DIFF
--- a/PyPaperBot/Paper.py
+++ b/PyPaperBot/Paper.py
@@ -8,6 +8,7 @@ import bibtexparser
 import re
 import csv
 import os
+import urllib.parse
 
 
 class Paper:
@@ -28,12 +29,17 @@ class Paper:
 
         self.downloaded = False
         self.downloadedFrom = 0  # 1-SciHub 2-scholar
+        
+        self.use_doi_as_filename = False # if True, the filename will be the DOI
 
     def getFileName(self):
-        try:
-            return re.sub(r'[^\w\-_. ]', '_', self.title) + ".pdf"
-        except:
-            return "none.pdf"
+        if self.use_doi_as_filename:
+            return urllib.parse.quote(self.DOI, safe='') + ".pdf"
+        else:
+            try:
+                return re.sub(r'[^\w\-_. ]', '_', self.title) + ".pdf"
+            except:
+                return "none.pdf"
 
     def setBibtex(self, bibtex):
         x = bibtexparser.loads(bibtex, parser=None)

--- a/PyPaperBot/__main__.py
+++ b/PyPaperBot/__main__.py
@@ -12,7 +12,8 @@ from .Crossref import getPapersInfoFromDOIs
 from .proxy import proxy
 
 def start(query, scholar_results, scholar_pages, dwn_dir, proxy, min_date=None, num_limit=None, num_limit_type=None,
-          filter_jurnal_file=None, restrict=None, DOIs=None, SciHub_URL=None, chrome_version=None, cites=None):
+          filter_jurnal_file=None, restrict=None, DOIs=None, SciHub_URL=None, chrome_version=None, cites=None,
+          use_doi_as_filename=False):
 
     to_download = []
     if DOIs is None:
@@ -27,6 +28,7 @@ def start(query, scholar_results, scholar_pages, dwn_dir, proxy, min_date=None, 
             DOI = DOIs[i]
             print("Searching paper {} of {} with DOI {}".format(num, len(DOIs), DOI))
             papersInfo = getPapersInfoFromDOIs(DOI, restrict)
+            papersInfo.use_doi_as_filename = use_doi_as_filename
             to_download.append(papersInfo)
 
             num += 1
@@ -91,6 +93,7 @@ def main():
                         help='Use a single proxy. Recommended if using --proxy gives errors')
     parser.add_argument('--selenium-chrome-version', type=int, default=None,
                         help='First three digits of the chrome version installed on your machine. If provided, selenium will be used for scholar search. It helps avoid bot detection but chrome must be installed.')
+    parser.add_argument('--use-doi-as-filename', action='store_true', default=False)
     args = parser.parse_args()
 
     if args.single_proxy is not None:
@@ -174,7 +177,8 @@ def main():
 
 
     start(args.query, args.scholar_results, scholar_pages, dwn_dir, proxy, args.min_year , max_dwn, max_dwn_type ,
-          args.journal_filter, args.restrict, DOIs, args.scihub_mirror, args.selenium_chrome_version, args.cites)
+          args.journal_filter, args.restrict, DOIs, args.scihub_mirror, args.selenium_chrome_version, args.cites,
+          args.use_doi_as_filename)
 
 if __name__ == "__main__":
     main()

--- a/PyPaperBot/__main__.py
+++ b/PyPaperBot/__main__.py
@@ -126,6 +126,11 @@ def main():
     dwn_dir = args.dwn_dir.replace('\\', '/')
     if dwn_dir[-1] != '/':
         dwn_dir += "/"
+    if os.path.exists(dwn_dir) and os.path.isdir(dwn_dir) and os.listdir(dwn_dir):
+        print("Error: The directory path provided is not empty")
+        sys.exit()
+    else:
+        os.makedirs(dwn_dir, exist_ok=True)
 
     if args.max_dwn_year is not None and args.max_dwn_cites is not None:
         print("Error: Only one option between '--max-dwn-year' and '--max-dwn-cites' can be used ")

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ PyPaperBot arguments:
 | \-\-proxy                   | Proxies to be used. Please specify the protocol to be used.                              | string |
 | \-\-single-proxy            | Use a single proxy. Recommended if using --proxy gives errors.                           | string |
 | \-\-selenium-chrome-version | First three digits of the chrome version installed on your machine. If provided, selenium will be used for scholar search. It helps avoid bot detection but chrome must be installed.                           | int    |
+| \-\-use-doi-as-filename | If provided, files are saved using the unique DOI as the filename rather than the default paper title            | bool    |
 | \-h                         | Shows the help                                                                           | --     |
 
 ### Note


### PR DESCRIPTION
This change allows for using a paper's unique DOI as the filename in place of the paper title.