### PR TITLE
Fix BibTeX Parsing Failures Caused by Month Strings (KeyError in bibdatabase.py)

### DIFF
--- a/PyPaperBot/Paper.py
+++ b/PyPaperBot/Paper.py
@@ -41,8 +41,10 @@ class Paper:
                 return "none.pdf"
 
     def setBibtex(self, bibtex):
-        x = bibtexparser.loads(bibtex, parser=None)
-        x = x.entries
+        pattern = r'(month\s*=\s*[\{\"]?)([A-Za-z]{3})[A-Za-z]*([\}\"]?)'
+        bibtex = re.sub(pattern, r'\1\2\3', bibtex, flags=re.IGNORECASE)
+        parser = bibtexparser.bparser.BibTexParser(common_strings=True)
+        x = bibtexparser.loads(bibtex, parser=parser)
 
         self.bibtex = bibtex
 


### PR DESCRIPTION
This PR resolves an issue where downloading certain papers fails due to bibtexparser failing to interpret month strings.

Related Issue
Fixes #78

Contributors to this fix: @ifenghm, @rimerinos